### PR TITLE
Initial stab at Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 0.8
+  - 0.9

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   ],
   "license": "MIT",
   "dependencies": {
+  },
+  "scripts": {
+    "test": "grunt jasmine"
   }
 }


### PR DESCRIPTION
TODO: Node tests
When this is ready, we should use the `loqi` account for travis hooks.
