### PR TITLE
There were 2 `scripts` keys after kyles travis yml merge. This fixes that.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
   ],
   "license": "MIT",
   "dependencies": {
-  },
-  "scripts": {
-    "test": "grunt jasmine"
   }
 }


### PR DESCRIPTION
There were 2 `scripts` keys after kyles travis yml merge. This fixes that.
