### PR TITLE
Add Travis CI image to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Terraformer
+# Terraformer [![](https://secure.travis-ci.org/geoloqi/Terraformer.png)](http://travis-ci.org/geoloqi/Terraformer)
 Terraformer is a small javascript library for working with GeoJSON. It is designed to be fast lightweight and usable in large numbers of environments including, browsers, AMD (require.js or Dojo), Node.js and inside Web Workers.
 
 * Convert to and from ArcGIS JSON Geometries, WKT and GeoJSON


### PR DESCRIPTION
This adds the Travis CI image to the Readme file.

Note that the tests are actually failing but Travis thinks they're passing because the script is not returning the right exit code (0 means success, but here it is returning success on a failure). Might want to wait until this gets fixed to merge this in.
