### PR TITLE
Feature/FeatureCollection with ID=0 fails to add in GeoStore. JSON.stringify() on Terraformer Feature Primitive drops id field.

### DIFF
--- a/src/geostore.js
+++ b/src/geostore.js
@@ -54,7 +54,8 @@
       throw new Error("Terraform.GeoStore : only Features and FeatureCollections are supported");
     }
 
-    if(geojson.type === "Feature" && !geojson.id) {
+    if(geojson.type === "Feature" && 
+       ((!geojson.hasOwnProperty("id")) || (geojson.id === null))) {
       throw new Error("Terraform.GeoStore : Feature does not have an id property");
     }
 
@@ -63,7 +64,7 @@
       for (var i = 0; i < geojson.features.length; i++) {
         var feature = geojson.features[i];
         bbox = Terraformer.Tools.calculateBounds(feature);
-        if(!feature.id) {
+        if((!feature.hasOwnProperty("id")) || feature.id === null) {
           throw new Error("Terraform.GeoStore : Feature does not have an id property");
         }
         this.index.insert({

--- a/src/terraformer.js
+++ b/src/terraformer.js
@@ -756,7 +756,7 @@
     toJSON: function(){
       var obj = {};
       for (var key in this) {
-        if (this.hasOwnProperty(key) && this[key] && excludeFromJSON.indexOf(key)) {
+        if (this.hasOwnProperty(key) && excludeFromJSON.indexOf(key) === -1) {
           obj[key] = this[key];
         }
       }


### PR DESCRIPTION
GeoStore would fail to add feature or featurecollection with id=0.

It also affected JSON.stringify() of a Terraformer Feature, which would just strip out the id attribute when id=0.
