### PR TITLE
removed trailing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
     "Jerry Sievert <jsievert@esri.com> (http://legitimatesounding.com)"
   ],
-  "license": "MIT",
+  "license": "MIT"
 }


### PR DESCRIPTION
Looks like the "dependencies" member was removed from the package json and the trailing comma prevents installation off the master tarball
