### PR TITLE
check if aws file exists

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,7 +1,8 @@
+var fs = require('fs');
 
 module.exports = function (grunt) {
+
   grunt.initConfig({
-    aws: grunt.file.readJSON(process.env.HOME + '/terraformer-s3.json'),
     pkg: grunt.file.readJSON('package.json'),
 
     jshint: {
@@ -127,6 +128,12 @@ module.exports = function (grunt) {
     }
 
   });
+
+  var awsExists = fs.existsSync(process.env.HOME + '/terraformer-s3.json');
+
+  if (awsExists) {
+    grunt.config.set('aws', grunt.file.readJSON(process.env.HOME + '/terraformer-s3.json'));
+  }
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-uglify');


### PR DESCRIPTION
This allows users to run grunt tasks without having aws keys for CDN deployments

Caveat: I'm not sure if grunt.config.set gets overriden by grunt.initConfig
