### PR TITLE
Visiting gh-pages shows broken version of terraformer.io

### DIFF
--- a/docs/layouts/default.erb
+++ b/docs/layouts/default.erb
@@ -13,7 +13,7 @@
     <%= stylesheet_link_tag "terraformer" %>
     <script>
       if (window.location.href.match('github.io')) {
-        window.location = window.location.replace('github.io', 'terraformer.io');
+        window.location.replace('http://terraformer.io' + window.location.pathname);
       }
     </script>
   </head>


### PR DESCRIPTION
http://esri.github.io/Terraformer/

We should either make css and js asset links relative or include something like the following in a script tag in the head:

``` js
if (document.location.toString().match('github.io')) {
  document.location = 'http://terraformer.io';
}
```
