### PR TITLE
circles are still not being closed with Circle.  New failing test illustrates it.

### DIFF
--- a/spec/terraformerSpec.js
+++ b/spec/terraformerSpec.js
@@ -494,7 +494,8 @@ describe("Primitives", function(){
     });
 
     it("should form a closed polygon", function(){
-      expect(circle.geometry.coordinates[0]).toEqual(circle.geometry.coordinates[circle.geometry.coordinates.length-1]);
+      expect(circle.geometry.coordinates[0][0][0]).toEqual(circle.geometry.coordinates[0][circle.geometry.coordinates[0].length-1][0]);
+      expect(circle.geometry.coordinates[0][0][1]).toEqual(circle.geometry.coordinates[0][circle.geometry.coordinates[0].length-1][1]);
     });
 
     it("should have a getter for steps", function(){


### PR DESCRIPTION
The previous test syntax was not working as intended because it was not
taking into account the nesting of the coordinates structure.

If you simply dump out the entire coordinate list returned, you can see
that the last point is not the same as the first point, as it should be.

This test update correctly takes the nesting into account and tests
both the latitude and longitude.
