### PR TITLE
Enhance close to work for Polygons with holes and MultiPolygons

### DIFF
--- a/spec/terraformerSpec.js
+++ b/spec/terraformerSpec.js
@@ -472,6 +472,31 @@ describe("Primitives", function(){
       expect(count).toEqual(2);
     });
 
+    it("should be able to be closed", function(){
+      var unclosed = new Terraformer.MultiPolygon({
+        "type": "MultiPolygon",
+        "coordinates": [
+          [
+            [ [102.0, 2.0],[103.0, 2.0],[103.0, 3.0],[102.0, 3.0] ],
+            [ [102.2, 2.2],[102.8, 2.2],[102.8, 2.8],[102.2, 2.8] ]
+          ],
+          [
+            [ [100.0, 0.0],[101.0, 0.0],[101.0, 1.0],[100.0, 1.0] ],
+            [ [100.2, 0.2],[100.8, 0.2],[100.8, 0.8],[100.2, 0.8] ]
+          ]
+        ]
+      });
+
+      unclosed.close();
+
+      unclosed.forEach(function(poly){
+        expect(poly[0].length).toEqual(5);
+        expect(poly[0][0][0]).toEqual(poly[0][poly[0].length-1][0]);
+        expect(poly[0][0][1]).toEqual(poly[0][poly[0].length-1][1]);
+      });
+
+    });
+
   });
 
   describe("Circle", function(){

--- a/terraformer.js
+++ b/terraformer.js
@@ -594,7 +594,6 @@
 
     for (var i = 0; i < coordinates.length; i++) {
       var inner = coordinates[i].slice();
-
       if (pointsEqual(inner[0], inner[inner.length - 1]) === false) {
         inner.push(inner[0]);
       }
@@ -1184,7 +1183,6 @@
     this.coordinates[0].splice(remove, 1);
     return this;
   };
-
   Polygon.prototype.close = function() {
     this.coordinates = closedPolygon(this.coordinates);
   };
@@ -1219,6 +1217,14 @@
   };
   MultiPolygon.prototype.get = function(i){
     return new Polygon(this.coordinates[i]);
+  };
+  MultiPolygon.prototype.close = function(){
+    var outer = [];
+    this.forEach(function(polygon){
+      outer.push(closedPolygon(polygon));
+    });
+    this.coordinates = outer;
+    return this;
   };
 
   /*


### PR DESCRIPTION
Currently the `close()` method will only work with polygons with a single ring.

It would be nice if `close()` would close all rings and work on MultiPolygons as well.

We should also expose a `Tools.closeCoordinates` and a `Tools.closeRing` function as well.
