### PR TITLE
make addVertex append before the closing point

### DIFF
--- a/spec/terraformerSpec.js
+++ b/spec/terraformerSpec.js
@@ -387,7 +387,7 @@ describe("Primitives", function(){
 
     it("should be able to add a vertex", function(){
       polygon.addVertex([45, 100]);
-      expect(polygon.coordinates).toEqual([ [ [100.0, 0.0],[101.0, 0.0],[101.0, 1.0],[100.0, 1.0],[100.0, 0.0],[45, 100] ] ]);
+      expect(polygon.coordinates).toEqual([ [ [100.0, 0.0],[101.0, 0.0],[101.0, 1.0],[100.0, 1.0],[45, 100],[100.0, 0.0] ] ]);
     });
 
     it("should be able to insert a vertex", function(){

--- a/terraformer.js
+++ b/terraformer.js
@@ -1105,7 +1105,7 @@
   Polygon.prototype = new Primitive();
   Polygon.prototype.constructor = Polygon;
   Polygon.prototype.addVertex = function(point){
-    this.coordinates[0].push(point);
+    this.insertVertex(point, this.coordinates[0].length - 1);
     return this;
   };
   Polygon.prototype.insertVertex = function(point, index){


### PR DESCRIPTION
`addVertex()` was pushing the new point onto the end of the outer polygon array, which makes it not a linear ring, which makes it not a polygon. that seemed bad to me, so i made it insert the new point just before the closing point.
