### PR TITLE
Make the "Using in Node.js" sample match the usage throughout the rest of the page

### DIFF
--- a/docs/arcgis-parser.html.md
+++ b/docs/arcgis-parser.html.md
@@ -49,7 +49,7 @@ $ bower install terraformer-arcgis-parser
 Just install the package from NPM with `$ npm install terraformer-arcgis-parser` Then include it in your application.
 
 ```js
-var Terraformer.ArcGIS = require('terraformer-arcgis-parser');
+Terraformer.ArcGIS = require('terraformer-arcgis-parser');
 
 // Start using the parse and convert methods!
 ```

--- a/docs/arcgis-parser.html.md
+++ b/docs/arcgis-parser.html.md
@@ -49,7 +49,7 @@ $ bower install terraformer-arcgis-parser
 Just install the package from NPM with `$ npm install terraformer-arcgis-parser` Then include it in your application.
 
 ```js
-var ArcGIS = require('terraformer-arcgis-parser');
+var Terraformer.ArcGIS = require('terraformer-arcgis-parser');
 
 // Start using the parse and convert methods!
 ```


### PR DESCRIPTION
Everything else talks about Terraformer.ArcGIS.parse() etc.