### PR TITLE
updating browser samples to 3.10

### DIFF
--- a/examples/browser/arcgis-geojson/index.html
+++ b/examples/browser/arcgis-geojson/index.html
@@ -10,10 +10,11 @@
     <script src="../../lib/terraformer-geostore-rtree.js" type="text/javascript"></script>
     <script src="../../lib/terraformer-arcgis-parser.js" type="text/javascript"></script>
 
-    <link rel="stylesheet" href="http://js.arcgis.com/3.7/js/esri/css/esri.css" />
-    <script src="http://js.arcgis.com/3.7/" type="text/javascript"></script>
-    <script src="counties.js"></script>
+    <link rel="stylesheet" href="http://js.arcgis.com/3.10/js/esri/css/esri.css" />
+    <script src="http://js.arcgis.com/3.10/" type="text/javascript"></script>
+    <!-- load supporting JavaScript and GeoJson for US Counties-->
     <script src="viewer.js"></script>
+    <script src="counties.js"></script>
     <style>
       html,body {
         margin: 0;

--- a/examples/browser/arcgis-geojson/viewer.js
+++ b/examples/browser/arcgis-geojson/viewer.js
@@ -7,8 +7,9 @@ require([
   "esri/graphic",
   "esri/symbols/SimpleLineSymbol",
   "esri/symbols/SimpleFillSymbol",
+  "esri/Color",
   "esri/geometry/jsonUtils"
-], function (query, Map, Geometry, Graphic, SimpleLineSymbol, SimpleFillSymbol, JsonUtils) {
+], function (query, Map, Geometry, Graphic, SimpleLineSymbol, SimpleFillSymbol, Color, geometryJsonUtils) {
 
   var map = new Map("map", {
     basemap: "gray",
@@ -36,12 +37,12 @@ require([
       var arcgis = Terraformer.ArcGIS.convert(county);
 
       // convert to an esri geometry
-      var geometry = JsonUtils.fromJson(arcgis.geometry);
+      var geometry = geometryJsonUtils.fromJson(arcgis.geometry);
 
       // make a new graphic for the map
       var gfx = new Graphic(geometry, new SimpleFillSymbol(SimpleFillSymbol.STYLE_SOLID,
         new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
-        new dojo.Color([100,155,55]),1), new dojo.Color([155,255,100,0.35])));
+        new Color([100,155,55]),1), new Color([155,255,100,0.35])));
 
       // add the graphic to the map
       map.graphics.add(gfx);
@@ -56,7 +57,6 @@ require([
       // Query location
       var def = CountyGeoStore.contains({
         type: "Point",
-        //coordinates: [ -122.61923540493, 45.533841334631 ]
         coordinates: [ lng, lat ]
       },function(err,results){
         if (results.length) {
@@ -64,13 +64,15 @@ require([
 
           // add highlighted county graphic to map, center and zoom
           var arcgis = Terraformer.ArcGIS.convert(results[0]);
-          var geometry = JsonUtils.fromJson(arcgis.geometry);
+          var geometry = geometryJsonUtils.fromJson(arcgis.geometry);
 
+          //create a new graphic using the geometry of the search result, setting both the fill and outline style.
           var gfx = new Graphic(geometry, new SimpleFillSymbol(SimpleFillSymbol.STYLE_SOLID,
             new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
             new dojo.Color([255,155,55]),2), new dojo.Color([255,155,100,0.45])));
 
           map.graphics.add(gfx);
+          //zoom in the map to the extent of the search result
           map.setExtent(geometry.getExtent(), true);
         } else {
           query("#whereami")[0].innerHTML = "We couldn't find where you were. Or you aren't in a country right now.";
@@ -78,6 +80,6 @@ require([
       });
     });
   }
-
+  //wire up event listener to track when someone clicks on the button in the top righthand corner
   query("#submit").on("click", findMe);
 });

--- a/examples/browser/arcgis-interactive-loader/index.html
+++ b/examples/browser/arcgis-interactive-loader/index.html
@@ -8,8 +8,8 @@
     <script src="../../lib/terraformer-wkt-parser.js" type="text/javascript"></script>
     <script src="../../lib/terraformer-arcgis-parser.js" type="text/javascript"></script>
 
-    <link rel="stylesheet" href="http://js.arcgis.com/3.7/js/esri/css/esri.css" />
-    <script src="http://js.arcgis.com/3.7/" type="text/javascript"></script>
+    <link rel="stylesheet" href="http://js.arcgis.com/3.10/js/esri/css/esri.css" />
+    <script src="http://js.arcgis.com/3.10/" type="text/javascript"></script>
     
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
@@ -45,7 +45,6 @@
             <li><a href="#arcgis">ArcGIS</a></li>
           </ul>
           <div class="tab-content">
-
             <div id="geojson" class="tab-pane active">
               <textarea placeholder="GeoJSON" data-type="geojson">{"type":"FeatureCollection","properties":{"kind":"state","state":"OR"},"features":[ {"type":"Feature","properties":{"kind":"county","name":"Washington","state":"OR"},"geometry":{"type":"MultiPolygon","coordinates":[[[[-123.1347,45.7798],[-123.0306,45.7798],[-123.0306,45.7524],[-122.9265,45.7250],[-122.9265,45.6319],[-122.7458,45.5169],[-122.7458,45.4348],[-122.7458,45.3307],[-122.8444,45.3471],[-122.8663,45.3197],[-123.0635,45.4019],[-123.1347,45.4348],[-123.4633,45.4348],[-123.4852,45.4457],[-123.4414,45.5224],[-123.2990,45.5936],[-123.4852,45.6812],[-123.4852,45.7086],[-123.3592,45.7086],[-123.3592,45.7798],[-123.1347,45.7798]]]]}} ]}</textarea>
             </div>

--- a/examples/browser/arcgis-wkt/index.html
+++ b/examples/browser/arcgis-wkt/index.html
@@ -7,8 +7,8 @@
     <script src="../../lib/terraformer-wkt-parser.js" type="text/javascript"></script>
     <script src="../../lib/terraformer-arcgis-parser.js" type="text/javascript"></script>
 
-    <link rel="stylesheet" href="http://js.arcgis.com/3.7/js/esri/css/esri.css" />
-    <script src="http://js.arcgis.com/3.7/" type="text/javascript"></script>
+    <link rel="stylesheet" href="http://js.arcgis.com/3.10/js/esri/css/esri.css" />
+    <script src="http://js.arcgis.com/3.10/" type="text/javascript"></script>
     <script src="viewer.js"></script>
     <style>
       html, body {

--- a/examples/browser/arcgis-wkt/viewer.js
+++ b/examples/browser/arcgis-wkt/viewer.js
@@ -3,8 +3,9 @@ require([
   "esri/map",
   "esri/symbols/SimpleLineSymbol",
   "esri/graphic",
+  "esri/geometry/jsonUtils",
   "dojo/domReady!"
-], function (query, Map, SimpleLineSymbol, Graphic) {
+], function (query, Map, SimpleLineSymbol, Graphic, geometryJsonUtils) {
 
   var map = new Map("map", {
     basemap: "national-geographic",
@@ -25,7 +26,7 @@ require([
     var arcgis = Terraformer.ArcGIS.convert(primitive);
 
     // create a new geometry object from json
-    var geometry = esri.geometry.fromJson(arcgis);
+    var geometry = geometryJsonUtils.fromJson(arcgis);
 
     // make a new graphic to put on the map
     var gfx = new Graphic(geometry, new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,new dojo.Color([0,0,255,0.5]), 4));


### PR DESCRIPTION
updated browser samples to use version 3.10 of the JS API and made a few fixes to AMDify and get convex hulls working

i noticed that the links to these samples in @aaronpk 's blog are 404ing now.
http://blogs.esri.com/esri/arcgis/2013/07/31/new-esri-open-source-javascript-projects-leaflet-geoservices-js-terraformer-pushlet/

if they aren't running live anywhere, would it be okay for me to add them to gh-pages?