### PR TITLE
Supporting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ The Terraformer project to broken up into a series of smaller modules.
 
 Check out the getting [started guide](http://terraformer.io/getting-started/) which will give you an overview of core concepts and methods in Terraformer.
 
+### Browser
+To use the Terraformer library, you **must include** the core Terraformer library with a `<script>` tag.
+
+If you would like to utilize any of the Terraformer packages: ArcGIS parser, WKT parser, or GeoStore, you must include the library with a `<script>` tag in addition to the Terraformer library.
+
+```html
+<!--Terraformer Library (Required)
+Learn more: https://github.com/Esri/Terraformer-->
+<script src="http://cdn-geoweb.s3.amazonaws.com/terraformer/1.0.4/terraformer.min.js"></script>
+
+<!--Terraformer Packages (Optional)-->
+<script src="terraformer-arcgis-parser.min.js"></script><!--Define ArcGIS Parser package: https://github.com/Esri/terraformer-arcgis-parser-->
+<script src="terraformer-wkt-parser.min.js"></script> <!--Define WKT Parser package: https://github.com/Esri/terraformer-wkt-parser-->
+<script src="terraformer-geostore.min.js"></script> <!--Define GeoStore package: https://github.com/Esri/terraformer-geostore-->
+```
+
 ## Documentation
 
 Make sure your check out the full documentation on the [Terraformer website](http://terraformer.io/core/) and the [getting started guide](http://terraformer.io/getting-started/).

--- a/docs/getting-started.html.md
+++ b/docs/getting-started.html.md
@@ -21,10 +21,19 @@ There are currently several packages in the Terraformer ecosystem.
 
 ### Browser
 
-Include the core Terraformer library with a `<script>` tag.
+To use the Terraformer library, you **must include** the core Terraformer library with a `<script>` tag.
+
+If you would like to utilize any of the Terraformer packages: [ArcGIS Parser](/arcgis-parser/), [WKT Parser](/wkt-parser/) , or [GeoStore](/geostore/), you must include the library with a `<script>` tag in addition to the Terraformer library.
 
 ```html
+<!--Terraformer Library (Required)
+Learn more: https://github.com/Esri/Terraformer-->
 <script src="http://cdn-geoweb.s3.amazonaws.com/terraformer/1.0.4/terraformer.min.js"></script>
+
+<!--Terraformer Packages (Optional)-->
+<script src="terraformer-arcgis-parser.min.js"></script><!--Define ArcGIS Parser package: https://github.com/Esri/terraformer-arcgis-parser-->
+<script src="terraformer-wkt-parser.min.js"></script> <!--Define WKT Parser package: https://github.com/Esri/terraformer-wkt-parser-->
+<script src="terraformer-geostore.min.js"></script> <!--Define GeoStore package: https://github.com/Esri/terraformer-geostore-->
 ```
 
 ### Node.js


### PR DESCRIPTION
Adding in the documentation changes as identified in #245. The documentation aims to provide a more meaningful, and accessible way for users to get to the GitHub repo's where the package's minified JavaScript files reside. :book: 

A few notes:
* The proposed changes **do not** include CDN's, as mentioned in @alaframboise's note. 
* The proposed changes include updates to **both** the `README.md` and [Getting Started](http://terraformer.io/getting-started/) page.  
