### PR TITLE
incorporate design suggestions and start shipping browser demos

### DIFF
--- a/docs/getting-started.html.md
+++ b/docs/getting-started.html.md
@@ -54,6 +54,8 @@ To utilize supporting packages, you must load their source as well.
 <script src="https://unpkg.com/terraformer-wkt-parser@1.1.2"></script> 
 ```
 
+To see Terraformer in action in the browser, check out our [live demos](/examples/browser/index.html).
+
 ## Working with Primitives
 
 Most of the core Terraformer libray centers around using [`Primitives`](/core/#terraformerprimitive), which wrap GeoJSON objects and provide additional functionality.

--- a/docs/install.html.md
+++ b/docs/install.html.md
@@ -7,7 +7,7 @@ layout: documentation
 
 <!-- table_of_contents -->
 
-We make Terraformer available via a number of distribution methods including NPM, Bower and a CDN.
+We make Terraformer available via npm, bower and via a CDN.
 
 ##Terraformer Core
 

--- a/examples/browser/arcgis-interactive-loader/index.html
+++ b/examples/browser/arcgis-interactive-loader/index.html
@@ -11,64 +11,87 @@
     <link rel="stylesheet" href="https://js.arcgis.com/3.19/esri/css/esri.css" />
     <script src="http://js.arcgis.com/3.19/" type="text/javascript"></script>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
-    <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
-    <script src="viewer.js"></script>
-    <style>
-      #map {
-        height: 500px;
-        width: 65%;
-        float: right;
-      }
-      #inputs {
-        width: 35%;
-        float: left;
-      }
-      textarea {
-        height: 380px;
-        box-sizing: border-box;
-        width: 100%;
-      }
-      .nav-pills {
-        padding: 10px 10px 0;
-      }
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+    <script src="viewer.js"></script>
+
+    <style>
+    #map {
+      height: 500px;
+      width: 100%;
+      float: right;
+      border: 1px solid #ddd;
+    }
+    #inputs {
+      width: 100%;
+      float: left;
+    }
+    textarea.form-control {
+      height: 380px;
+      box-sizing: border-box;
+      width: 100%;
+    }
+    .tab-content{
+      border: 1px solid #ddd;
+      padding: 1rem;
+      border-top: 0;
+    }
     </style>
   </head>
   <body>
-        <div id="map"></div>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="page-header">
+          <h1>Terraformer<small> (Browser demo)</small></h1>
+        </div>
+      </div>
+
+      <div class="col-md-6">
         <div id="inputs">
-          <ul id="tabs" class="nav nav-pills">
-            <li class="active"><a href="#geojson">GeoJSON</a></li>
-            <li><a href="#wkt">WKT</a></li>
+          <ul id="tabs" class="nav nav nav-tabs">
+            <li class="active">
+              <a href="#wkt">WKT</a>
+            </li>
+            <li><a href="#geojson">GeoJSON</a></li>
             <li><a href="#arcgis">ArcGIS</a></li>
           </ul>
           <div class="tab-content">
-            <div id="geojson" class="tab-pane active">
-              <textarea placeholder="GeoJSON" data-type="geojson">{"type":"FeatureCollection","properties":{"kind":"state","state":"OR"},"features":[ {"type":"Feature","properties":{"kind":"county","name":"Washington","state":"OR"},"geometry":{"type":"MultiPolygon","coordinates":[[[[-123.1347,45.7798],[-123.0306,45.7798],[-123.0306,45.7524],[-122.9265,45.7250],[-122.9265,45.6319],[-122.7458,45.5169],[-122.7458,45.4348],[-122.7458,45.3307],[-122.8444,45.3471],[-122.8663,45.3197],[-123.0635,45.4019],[-123.1347,45.4348],[-123.4633,45.4348],[-123.4852,45.4457],[-123.4414,45.5224],[-123.2990,45.5936],[-123.4852,45.6812],[-123.4852,45.7086],[-123.3592,45.7086],[-123.3592,45.7798],[-123.1347,45.7798]]]]}} ]}</textarea>
+            <div id="wkt" class="tab-pane active">
+              <textarea class="form-control" placeholder="WKT" data-type="wkt">MULTIPOLYGON (((-122.9265 45.725, -122.7622 45.7305, -122.7622 45.6593, -122.6746 45.6155, -122.2474 45.5498, -121.9243 45.6484, -121.9024 45.5552, -121.9243 45.5443, -121.8202 45.4621, -122.3569 45.4621, -122.7458 45.4348, -122.7458 45.5169, -122.9265 45.6319, -122.9265 45.725)))</textarea>
             </div>
 
-            <div id="wkt" class="tab-pane">
-              <textarea placeholder="WKT" data-type="wkt">MULTIPOLYGON (((-122.9265 45.725, -122.7622 45.7305, -122.7622 45.6593, -122.6746 45.6155, -122.2474 45.5498, -121.9243 45.6484, -121.9024 45.5552, -121.9243 45.5443, -121.8202 45.4621, -122.3569 45.4621, -122.7458 45.4348, -122.7458 45.5169, -122.9265 45.6319, -122.9265 45.725)))</textarea>
+            <div id="geojson" class="tab-pane" >
+              <textarea class="form-control" placeholder="GeoJSON" data-type="geojson">{"type":"FeatureCollection","properties":{"kind":"state","state":"OR"},"features":[ {"type":"Feature","properties":{"kind":"county","name":"Washington","state":"OR"},"geometry":{"type":"MultiPolygon","coordinates":[[[[-123.1347,45.7798],[-123.0306,45.7798],[-123.0306,45.7524],[-122.9265,45.7250],[-122.9265,45.6319],[-122.7458,45.5169],[-122.7458,45.4348],[-122.7458,45.3307],[-122.8444,45.3471],[-122.8663,45.3197],[-123.0635,45.4019],[-123.1347,45.4348],[-123.4633,45.4348],[-123.4852,45.4457],[-123.4414,45.5224],[-123.2990,45.5936],[-123.4852,45.6812],[-123.4852,45.7086],[-123.3592,45.7086],[-123.3592,45.7798],[-123.1347,45.7798]]]]}} ]}</textarea>
             </div>
 
             <div id="arcgis" class="tab-pane">
-              <textarea placeholder="ArcGIS" data-type="arcgis">{"geometry":{"rings":[[[-122.7458,45.4348],[-122.7458,45.3307],[-122.8444,45.3471],[-122.8663,45.3197],[-122.8499,45.2595],[-122.7403,45.2595],[-122.7896,45.128],[-122.5979,45.0185],[-122.5048,44.9199],[-122.3953,44.8871],[-121.7326,44.8871],[-121.7161,44.9035],[-121.7983,44.9363],[-121.8038,45.013],[-121.6614,45.0678],[-121.6669,45.1171],[-121.6997,45.1226],[-121.749,45.1992],[-121.6833,45.2266],[-121.6942,45.2595],[-121.6997,45.38],[-121.7764,45.4019],[-121.8202,45.4621],[-122.3569,45.4621],[-122.7458,45.4348]]],"spatialReference":{"wkid":4326}},"attributes":{"kind":"county","name":"Clackamas","state":"OR"}}</textarea>
+              <textarea class="form-control" placeholder="ArcGIS" data-type="arcgis">{"geometry":{"rings":[[[-122.7458,45.4348],[-122.7458,45.3307],[-122.8444,45.3471],[-122.8663,45.3197],[-122.8499,45.2595],[-122.7403,45.2595],[-122.7896,45.128],[-122.5979,45.0185],[-122.5048,44.9199],[-122.3953,44.8871],[-121.7326,44.8871],[-121.7161,44.9035],[-121.7983,44.9363],[-121.8038,45.013],[-121.6614,45.0678],[-121.6669,45.1171],[-121.6997,45.1226],[-121.749,45.1992],[-121.6833,45.2266],[-121.6942,45.2595],[-121.6997,45.38],[-121.7764,45.4019],[-121.8202,45.4621],[-122.3569,45.4621],[-122.7458,45.4348]]],"spatialReference":{"wkid":4326}},"attributes":{"kind":"county","name":"Clackamas","state":"OR"}}</textarea>
             </div>
-
             <br>
-            <button id="submit" class="btn btn-small">Show On Map</button>
-            <button id="bounding" class="btn btn-small">Bounding Box</button>
-            <button id="convex" class="btn btn-small">Convex Hull</button>
-            <button id="clear" class="btn btn-small">Clear</button>
+            <button id="submit" class="btn btn-primary btn-small">Show On Map</button>
+            <button id="bounding" class="btn btn-success btn-small">Bounding Box</button>
+            <button id="convex" class="btn btn-warning btn-small">Convex Hull</button>
+            <button id="clear" class="btn btn-default btn-small">Clear</button>
           </div>
+        </div>
       </div>
-      <script>
-      $('#tabs a').click(function (e) {
-        e.preventDefault();
-        $(this).tab(  'show');
-      });
-    </script>
-  </body>
+      <div class="col-md-6">
+        <div id="map"></div>
+      </div>
+    </div>
+  </div>
+
+  <a href="https://github.com/Esri/terraformer-demo"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+  <script>
+  $('#tabs a').click(function (e) {
+    e.preventDefault();
+    $(this).tab('show');
+  });
+  </script>
+</body>
 </html>

--- a/examples/browser/arcgis-interactive-loader/viewer.js
+++ b/examples/browser/arcgis-interactive-loader/viewer.js
@@ -3,7 +3,7 @@ require([
   "dojo/dom",
   "esri/map",
   "esri/graphic",
-  "esri/symbols/SimpleFillSymbol", 
+  "esri/symbols/SimpleFillSymbol",
   "esri/symbols/SimpleLineSymbol",
   "esri/Color",
   "esri/geometry/jsonUtils"
@@ -26,7 +26,7 @@ require([
   function showGeoJSON(geojson){
     //create a Terraformer GeoJSON primitive
     var geoJsonPrimitive = new Terraformer.Primitive(geojson);
-    
+
     arcgis = Terraformer.ArcGIS.convert(geoJsonPrimitive);
     for (var i=0; i < arcgis.length; i++){
       addGraphic(arcgis[i], new Color([255,255,0,0.25]));
@@ -115,7 +115,7 @@ require([
       }
 
       // center the map on the graphic
-      map.setExtent(gfx.geometry.getExtent());
+      map.setExtent(gfx.geometry.getExtent().expand(1.2));
     }
   }
 
@@ -144,8 +144,8 @@ require([
         shape.getDojoShape().moveToFront();
       }
       // center the map on the graphic
-      map.setExtent(gfx.geometry.getExtent());
-    }    
+      map.setExtent(gfx.geometry.getExtent().expand(1.2));
+    }
   }
 
   query("#submit").on("click", showOnMap);

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -51,7 +51,7 @@
       <ul>
         <li><a href="arcgis-wkt/index.html">ArcGIS WKT Viewer</a></li>
         <li><a href="leaflet-wkt/index.html">Leaflet WKT Viewer</a></li>
-        <li><a href="googlemaps-wkt/index.html">Google WKT Viewer</a></li>
+        <!--li><a href="googlemaps-wkt/index.html">Google WKT Viewer</a></li-->
       </ul>
        <h3>Terraformer Primitives, WKT &amp; ArcGIS Parser</h3>
       <ul>

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -111,7 +111,6 @@ module.exports = function (grunt) {
       src: ['**']
     },
 
-
     middleman: {
       server: {
         options: {
@@ -125,6 +124,15 @@ module.exports = function (grunt) {
           command: "build"
         }
       }
+    },
+
+    copy: {
+      main: {
+        files: [
+          // includes files within path and its sub-directories
+          {expand: true, src: ['examples/browser/**'], dest: 'docs-build/'}
+        ],
+      },
     }
 
   });
@@ -139,6 +147,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-complexity');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
+  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-jasmine-node');
   grunt.loadNpmTasks('grunt-s3');
   grunt.loadNpmTasks('grunt-gh-pages');
@@ -147,5 +156,6 @@ module.exports = function (grunt) {
   grunt.registerTask('test', ['jshint', 'jasmine_node', 'jasmine']);
   grunt.registerTask('version', ['test', 'uglify', 's3']);
   grunt.registerTask('default', ['test']);
-  grunt.registerTask('deploy-docs', ['middleman:build', 'gh-pages']);
+  grunt.registerTask('docs-build', ['middleman:build', 'copy']);
+  grunt.registerTask('deploy-docs', ['middleman:build', 'copy', 'gh-pages']);
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gh-release": "^2.1.0",
     "grunt": "0.4.x",
     "grunt-complexity": "~0.1.3",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-jasmine": "~0.4.2",
     "grunt-contrib-jshint": "0.6.x",
     "grunt-contrib-uglify": "~2.0.0",


### PR DESCRIPTION
this PR incorporates design work done by @hhkaos in Esri/terraformer-demo/pull/1

it also resolves #294, by shipping `/examples/browser/` along with the rest of the doc site.

(i commented out the google maps api sample because it requires an API key)
