### PR TITLE
Updated Circle examples

### DIFF
--- a/docs/core.html.md
+++ b/docs/core.html.md
@@ -279,7 +279,7 @@ Option | Type | Default | Description
 `steps` | `Integer` | `32` | How many steps will be used to create the polygon that represents the circle.
 
 ```js
-circle = new Terraformer.Circle([45.65, -122.27], 500, 64);
+circle = new Terraformer.Circle([-122.27, 45.65], 500, 64);
 
 circle.contains(point);
 ```

--- a/terraformer.d.ts
+++ b/terraformer.d.ts
@@ -182,7 +182,7 @@ declare namespace Terraformer {
     * The GeoJSON spec does not provide a way to visualize circles.
     * Terraformer.Circle is actual a GeoJSON Feature object that contains a Polygon representing a circle with a certain number of sides.
     * @example
-    * circle = new Terraformer.Circle([45.65, -122.27], 500, 64);
+    * circle = new Terraformer.Circle([-122.27, 45.65], 500, 64);
     *
     * circle.contains(point);
     */

--- a/test.ts
+++ b/test.ts
@@ -95,7 +95,7 @@ let geometrycollection1 = new Terraformer.GeometryCollection({
 
 let geometrycollection2 = new Terraformer.GeometryCollection([point2, polygon1]);
 
-let circle = new Terraformer.Circle([45.65, -122.27], 500, 64);
+let circle = new Terraformer.Circle([-122.27, 45.65], 500, 64);
 
 circle.contains(point1);
 


### PR DESCRIPTION
Fixed three references to a Circle example where it looked like `x` and `y` may have been swapped in the example.