### PR TITLE
Fix TS build error when a project contains conflicting versions of @types/geojson

### DIFF
--- a/terraformer.d.ts
+++ b/terraformer.d.ts
@@ -4,6 +4,8 @@
  * import * as Terraformer from "terraformer";
  */
 
+import * as GeoJSON from 'geojson';
+
 // Note: Terraformer module exports namespace so it can be augmented by
 // terraformer-wkt-parser and potentially others
 export as namespace Terraformer;


### PR DESCRIPTION
This PR fixes TS build error:

node_modules/terraformer/terraformer.d.ts:38:16 - error TS2416: Property 'type' in type 'Primitive<T>' is not assignable to the same property in base type 'GeoJsonObject'.
  Type 'string' is not assignable to type '"Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection" | "Feature" | "FeatureCollection"'.

TS 3.5.1 in strict build mode