### PR TITLE
Make Primitive type compatible with @types/geojson v7946.0.7

### DIFF
--- a/terraformer.d.ts
+++ b/terraformer.d.ts
@@ -35,7 +35,17 @@ declare namespace Terraformer {
     * polygon.
     */
     export class Primitive<T extends GeoJSON.GeoJsonObject> implements GeoJSON.GeoJsonObject {
-        public type: string;
+        public type:
+            | "Point"
+            | "MultiPoint"
+            | "LineString"
+            | "MultiLineString"
+            | "Polygon"
+            | "MultiPolygon"
+            | "GeometryCollection"
+            | "Feature"
+            | "FeatureCollection";
+
         /**
         * You create a new Terraformer.Primitive object by passing it a valid GeoJSON Object. This will return a
         * Terraformer.Primitive with the same type as your GeoJSON object.


### PR DESCRIPTION
Without this, those of us using more recent `geojson` types get:
````
node_modules/terraformer/terraformer.d.ts:38:16 - error TS2416: Property 'type' in type 'Primitive<T>' is not assignable to the same property in base type 'GeoJsonObject'.
  Type 'string' is not assignable to type '"Point" | "MultiPoint" | "LineString" | "MultiLineString" | "Polygon" | "MultiPolygon" | "GeometryCollection" | "Feature" | "FeatureCollection"'.

38         public type: string;
````