### PR TITLE
Add missing variable declaration

### DIFF
--- a/terraformer.js
+++ b/terraformer.js
@@ -753,7 +753,7 @@
   };
 
   Primitive.prototype.within = function(primitive) {
-    var coordinates, i, contains;
+    var coordinates, i, j, contains;
 
     // if we are passed a feature, use the polygon inside instead
     if (primitive.type === 'Feature') {

--- a/terraformer.js
+++ b/terraformer.js
@@ -11,6 +11,8 @@
   }
 
 }(this, function(){
+  "use strict";
+
   var exports = {},
       EarthRadius = 6378137,
       DegreesPerRadian = 57.295779513082320,

--- a/terraformer.js
+++ b/terraformer.js
@@ -1157,7 +1157,7 @@
     return this.coordinates.length > 1;
   };
   Polygon.prototype.holes = function() {
-    holes = [];
+    var holes = [];
     if (this.hasHoles()) {
       for (var i = 1; i < this.coordinates.length; i++) {
         holes.push(new Polygon([this.coordinates[i]]));


### PR DESCRIPTION
Missing `j` variable declaration in `within` method causes `ReferenceError: j is not defined`.

See https://github.com/zakjan/leaflet-lasso/issues/19