### PR TITLE
Stop depending on geojson types v1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "license": "MIT",
   "optionalDependencies": {
-    "@types/geojson": "^7946.0.0 || ^1.0.0"
+    "@types/geojson": "^7946.0.0"
   },
   "engines": {
     "node": ">=4.2.6"


### PR DESCRIPTION
Creating this PR based on what has been discussed on issue [#47](https://github.com/Esri/terraformer-wkt-parser/issues/47) of `terraformer-wkt-parser`.